### PR TITLE
Fix photo API failure handling

### DIFF
--- a/src/lib/photo-db.ts
+++ b/src/lib/photo-db.ts
@@ -7,7 +7,8 @@ const jsonHeaders = { 'Content-Type': 'application/json' };
 export const getPhotoGroups = async (): Promise<PhotoGroups> => {
   const res = await fetch('/api/photos');
   if (!res.ok) {
-    throw new Error('Failed to load photos');
+    console.error('Failed to load photos');
+    return {};
   }
   return res.json();
 };


### PR DESCRIPTION
## Summary
- handle failed `/api/photos` requests gracefully, logging an error and returning an empty object instead of throwing

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686aec6bdc708324acf07a82ae577003