### PR TITLE
Ignore duplicate photo uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ This example uses SQLite for storage instead of Firebase.
    ```
 
 To explore the code, start with `src/app/page.tsx`.
+
+When uploading photos through the admin interface, files that share the exact
+filename with an existing photo are skipped. A toast message shows how many
+photos were added and how many duplicates were ignored.

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -152,9 +152,12 @@ export default function PhotosPage() {
     const filesArray = Array.from(newPhotoFiles);
 
     try {
-      await addPhotos(filesArray, targetCategory);
+      const { inserted, duplicates } = await addPhotos(filesArray, targetCategory);
 
-      toast({ title: 'Upload Complete', description: `${filesArray.length} photo(s) added to "${targetCategory}".` });
+      const message = `${inserted.length} photo(s) added to "${targetCategory}".` +
+        (duplicates.length > 0 ? ` ${duplicates.length} duplicate file(s) were skipped.` : '');
+
+      toast({ title: 'Upload Complete', description: message });
       setNewPhotoFiles(null);
       const fileInput = document.getElementById('photo-file') as HTMLInputElement;
       if (fileInput) fileInput.value = '';

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { run, all } from '@/lib/sqlite';
+import { run, all, get } from '@/lib/sqlite';
 import type { Photo } from '@/lib/data';
 
 interface StoredPhoto extends Photo { group: string }
@@ -27,17 +27,25 @@ export async function POST(request: NextRequest) {
   const group = String(formData.get('group') || 'default');
   const files = formData.getAll('files') as File[];
   const inserted: Photo[] = [];
+  const duplicates: string[] = [];
 
   for (const file of files) {
+    const existing = await get<{ id: string }>('SELECT id FROM photos WHERE storage_path = ?', [file.name]);
+    if (existing) {
+      duplicates.push(file.name);
+      continue;
+    }
+
     const buffer = Buffer.from(await file.arrayBuffer());
     const id = crypto.randomUUID();
     const base64 = `data:${file.type};base64,${buffer.toString('base64')}`;
     const hint = file.name.substring(0, file.name.lastIndexOf('.')).replace(/[-_]/g, ' ');
     await run(
       'INSERT INTO photos (id, src, alt, data_ai_hint, storage_path, group_name, createdAt) VALUES (?, ?, ?, ?, ?, ?, ?)',
-      [id, base64, hint, hint.split(' ').slice(0,2).join(' '), '', group, Date.now()]
+      [id, base64, hint, hint.split(' ').slice(0,2).join(' '), file.name, group, Date.now()]
     );
-    inserted.push({ id, src: base64, alt: hint, 'data-ai-hint': hint.split(' ').slice(0,2).join(' '), storagePath: '' });
+    inserted.push({ id, src: base64, alt: hint, 'data-ai-hint': hint.split(' ').slice(0,2).join(' '), storagePath: file.name });
   }
-  return NextResponse.json(inserted, { status: 201 });
+
+  return NextResponse.json({ inserted, duplicates }, { status: 201 });
 }

--- a/src/lib/photo-db.ts
+++ b/src/lib/photo-db.ts
@@ -22,7 +22,12 @@ export const getPhotoCount = async (): Promise<number> => {
   return data.count as number;
 };
 
-export const addPhotos = async (files: File[], group: string): Promise<Photo[]> => {
+export type AddPhotosResponse = {
+  inserted: Photo[];
+  duplicates: string[];
+};
+
+export const addPhotos = async (files: File[], group: string): Promise<AddPhotosResponse> => {
   const formData = new FormData();
   files.forEach((f) => formData.append('files', f));
   formData.append('group', group);


### PR DESCRIPTION
## Summary
- note skipped duplicates in README
- return duplicate info from `addPhotos`
- show toast about skipped duplicates
- ignore previously imported files in `/api/photos` POST handler

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686b8dc56a008324908e55eabd34d37b