### PR TITLE
Add configurable message schedule

### DIFF
--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -32,6 +32,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -47,6 +54,8 @@ import { useToast } from '@/hooks/use-toast';
 import type { Message } from '@/lib/data';
 import { getMessages, addMessage, updateMessage, deleteMessage } from '@/lib/message-db';
 
+const scheduleOptions = ['Always Active', 'Morning', 'Afternoon', 'Evening', 'Night'];
+
 export default function MessagesPage() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -55,7 +64,7 @@ export default function MessagesPage() {
   const [editingMessage, setEditingMessage] = useState<Message | null>(null);
 
   const [newContent, setNewContent] = useState('');
-  const [newSchedule, setNewSchedule] = useState('');
+  const [newSchedule, setNewSchedule] = useState('Always Active');
   
   const { toast } = useToast();
 
@@ -203,13 +212,19 @@ export default function MessagesPage() {
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="schedule">Schedule (Optional)</Label>
-                  <Input
-                    id="schedule"
-                    value={newSchedule}
-                    onChange={(e) => setNewSchedule(e.target.value)}
-                    placeholder="e.g., Always Active, or 2024-08-15"
-                  />
+                  <Label htmlFor="schedule">Schedule</Label>
+                  <Select value={newSchedule} onValueChange={setNewSchedule}>
+                    <SelectTrigger id="schedule">
+                      <SelectValue placeholder="Select schedule" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {scheduleOptions.map((opt) => (
+                        <SelectItem key={opt} value={opt}>
+                          {opt}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
               <DialogFooter>
@@ -249,18 +264,24 @@ export default function MessagesPage() {
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="edit-schedule">Schedule (Optional)</Label>
-                  <Input
-                    id="edit-schedule"
+                  <Label htmlFor="edit-schedule">Schedule</Label>
+                  <Select
                     value={editingMessage.schedule}
-                    onChange={(e) =>
-                      setEditingMessage({
-                        ...editingMessage,
-                        schedule: e.target.value,
-                      })
+                    onValueChange={(value) =>
+                      setEditingMessage({ ...editingMessage, schedule: value })
                     }
-                    placeholder="e.g., Always Active, or 2024-08-15"
-                  />
+                  >
+                    <SelectTrigger id="edit-schedule">
+                      <SelectValue placeholder="Select schedule" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {scheduleOptions.map((opt) => (
+                        <SelectItem key={opt} value={opt}>
+                          {opt}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
             )}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -14,6 +14,13 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Slider } from '@/components/ui/slider';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import type { Settings } from '@/lib/data';
 import { defaultSettings } from '@/lib/data';
@@ -54,6 +61,10 @@ export default function SettingsPage() {
 
   const handleSliderChange = (id: keyof Settings, value: number[]) => {
     setSettings((prev) => ({ ...prev, [id]: value[0] }));
+  };
+
+  const handleSelectChange = (id: keyof Settings, value: string) => {
+    setSettings((prev) => ({ ...prev, [id]: Number(value) }));
   };
 
   const handleSaveChanges = async () => {
@@ -190,6 +201,50 @@ export default function SettingsPage() {
             <div className="space-y-3">
                 <Label htmlFor="messageFontSize">Message Font Size ({settings.messageFontSize}px)</Label>
                 <Slider id="messageFontSize" value={[settings.messageFontSize]} onValueChange={(value) => handleSliderChange('messageFontSize', value)} min={24} max={250} step={1} disabled={isDisabled}/>
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="morningStartHour">Morning Starts</Label>
+                <Select value={String(settings.morningStartHour)} onValueChange={(val) => handleSelectChange('morningStartHour', val)}>
+                    <SelectTrigger id="morningStartHour"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                        {Array.from({ length: 24 }, (_, i) => (
+                            <SelectItem key={i} value={String(i)}>{`${i}:00`}</SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="afternoonStartHour">Afternoon Starts</Label>
+                <Select value={String(settings.afternoonStartHour)} onValueChange={(val) => handleSelectChange('afternoonStartHour', val)}>
+                    <SelectTrigger id="afternoonStartHour"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                        {Array.from({ length: 24 }, (_, i) => (
+                            <SelectItem key={i} value={String(i)}>{`${i}:00`}</SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="eveningStartHour">Evening Starts</Label>
+                <Select value={String(settings.eveningStartHour)} onValueChange={(val) => handleSelectChange('eveningStartHour', val)}>
+                    <SelectTrigger id="eveningStartHour"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                        {Array.from({ length: 24 }, (_, i) => (
+                            <SelectItem key={i} value={String(i)}>{`${i}:00`}</SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="nightStartHour">Night Starts</Label>
+                <Select value={String(settings.nightStartHour)} onValueChange={(val) => handleSelectChange('nightStartHour', val)}>
+                    <SelectTrigger id="nightStartHour"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                        {Array.from({ length: 24 }, (_, i) => (
+                            <SelectItem key={i} value={String(i)}>{`${i}:00`}</SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
             </div>
         </CardContent>
       </Card>

--- a/src/components/display-board.tsx
+++ b/src/components/display-board.tsx
@@ -33,6 +33,29 @@ const shuffle = <T,>(array: T[]): T[] => {
   return newArray;
 };
 
+const isNowBetween = (start: number, end: number, hour: number) => {
+  if (start <= end) {
+    return hour >= start && hour < end;
+  }
+  return hour >= start || hour < end;
+};
+
+const isMessageScheduled = (msg: Message, settings: Settings) => {
+  const hour = new Date().getHours();
+  switch (msg.schedule) {
+    case 'Morning':
+      return isNowBetween(settings.morningStartHour, settings.afternoonStartHour, hour);
+    case 'Afternoon':
+      return isNowBetween(settings.afternoonStartHour, settings.eveningStartHour, hour);
+    case 'Evening':
+      return isNowBetween(settings.eveningStartHour, settings.nightStartHour, hour);
+    case 'Night':
+      return isNowBetween(settings.nightStartHour, settings.morningStartHour, hour);
+    default:
+      return true;
+  }
+};
+
 export function DisplayBoard({ 
   onStatusChange,
   onBlankScreenChange,
@@ -99,7 +122,9 @@ export function DisplayBoard({
           
           // 2. Add messages if enabled
           if (loadedSettings.displayMessages) {
-              const activeMessages = messages.filter(m => m.status === 'Active');
+              const activeMessages = messages.filter(
+                (m) => m.status === 'Active' && isMessageScheduled(m, loadedSettings)
+              );
               const getMessageDuration = (text: string) => {
                 const baseDuration = (text.split(/\s+/).length * 0.5 + 5) * 1000;
                 const scrollFactor = (150 - loadedSettings.scrollSpeed) / 50; 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -30,6 +30,10 @@ export type Settings = {
   displayMessages: boolean;
   useBlankScreens: boolean;
   monitorActivity: boolean;
+  morningStartHour: number;
+  afternoonStartHour: number;
+  eveningStartHour: number;
+  nightStartHour: number;
 };
 
 export const defaultSettings: Settings = {
@@ -44,4 +48,8 @@ export const defaultSettings: Settings = {
   displayMessages: true,
   useBlankScreens: true,
   monitorActivity: false,
+  morningStartHour: 6,
+  afternoonStartHour: 12,
+  eveningStartHour: 18,
+  nightStartHour: 22,
 };


### PR DESCRIPTION
## Summary
- allow selecting message schedule from dropdowns
- filter messages based on schedule when building display queue
- store configurable schedule start hours
- let admins set schedule start times in settings

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_686c38945fec83248cdb6e0b5d65b124