### PR TITLE
Add photo deduplication option

### DIFF
--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -274,6 +274,19 @@ export default function PhotosPage() {
     }
   };
 
+  const handleRemoveDuplicates = async () => {
+    try {
+      const res = await fetch('/api/photos/remove-duplicates', { method: 'POST' });
+      if (!res.ok) throw new Error('Failed');
+      const data = await res.json();
+      toast({ title: 'Duplicates Removed', description: `${data.removed} duplicate(s) deleted.` });
+      fetchPhotos();
+    } catch (error) {
+      console.error('Failed to remove duplicates', error);
+      toast({ variant: 'destructive', title: 'Error', description: 'Could not remove duplicate photos.' });
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="flex-1 space-y-4">
@@ -394,6 +407,7 @@ export default function PhotosPage() {
               </form>
             </DialogContent>
           </Dialog>
+          <Button variant="outline" onClick={handleRemoveDuplicates}>Remove Duplicates</Button>
         </div>
       </div>
       <Dialog open={isEditDialogOpen} onOpenChange={handleEditDialogChange}>

--- a/src/app/api/photos/remove-duplicates/route.ts
+++ b/src/app/api/photos/remove-duplicates/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { all, run } from "@/lib/sqlite";
+
+export async function POST() {
+  const rows = await all<{ id: string; storage_path: string }>(
+    "SELECT id, storage_path FROM photos ORDER BY createdAt ASC",
+  );
+  const seen = new Set<string>();
+  const idsToDelete: string[] = [];
+
+  for (const row of rows) {
+    if (row.storage_path && seen.has(row.storage_path)) {
+      idsToDelete.push(row.id);
+    } else if (row.storage_path) {
+      seen.add(row.storage_path);
+    }
+  }
+
+  for (const id of idsToDelete) {
+    await run("DELETE FROM photos WHERE id = ?", [id]);
+  }
+
+  return NextResponse.json({ removed: idsToDelete.length });
+}


### PR DESCRIPTION
## Summary
- add API endpoint to remove duplicate photos
- add handler and button in admin photo management page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_686cc74b25648324a9ba7b8107da1a50