### PR TITLE
Fix duplicate photo detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ This example uses SQLite for storage instead of Firebase.
 
 To explore the code, start with `src/app/page.tsx`.
 
-When uploading photos through the admin interface, files that share the exact
-filename with an existing photo are skipped. A toast message shows how many
-photos were added and how many duplicates were ignored.
+When uploading photos through the admin interface, files with identical content
+are skipped (duplicates are detected using a SHA-256 hash). A toast message
+shows how many photos were added and how many duplicates were ignored.

--- a/src/lib/sqlite.ts
+++ b/src/lib/sqlite.ts
@@ -26,9 +26,17 @@ function getDatabase(): Promise<sqlite3.Database> {
           alt TEXT NOT NULL,
           data_ai_hint TEXT,
           storage_path TEXT,
+          hash TEXT,
           group_name TEXT,
           createdAt INTEGER
         );`);
+        database.all('PRAGMA table_info(photos);', (err, rows) => {
+          if (err) return;
+          const hasHash = rows.some((r: any) => r.name === 'hash');
+          if (!hasHash) {
+            database.run('ALTER TABLE photos ADD COLUMN hash TEXT;');
+          }
+        });
         database.run(`CREATE TABLE IF NOT EXISTS settings (
           id INTEGER PRIMARY KEY CHECK (id = 1),
           data TEXT NOT NULL


### PR DESCRIPTION
## Summary
- use SHA-256 hash for duplicate detection
- persist photo hashes in SQLite
- update duplicate cleanup to use hashes
- document the new duplicate handling method

## Testing
- `npm run typecheck` *(fails: Cannot find module)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ccaeae0388324870af69093134991