### PR TITLE
Add photo display mode setting

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -64,7 +64,10 @@ export default function SettingsPage() {
   };
 
   const handleSelectChange = (id: keyof Settings, value: string) => {
-    setSettings((prev) => ({ ...prev, [id]: Number(value) }));
+    setSettings((prev) => ({
+      ...prev,
+      [id]: id === 'photoDisplayMode' ? value : Number(value),
+    }));
   };
 
   const handleSaveChanges = async () => {
@@ -201,6 +204,17 @@ export default function SettingsPage() {
             <div className="space-y-3">
                 <Label htmlFor="messageFontSize">Message Font Size ({settings.messageFontSize}px)</Label>
                 <Slider id="messageFontSize" value={[settings.messageFontSize]} onValueChange={(value) => handleSliderChange('messageFontSize', value)} min={24} max={250} step={1} disabled={isDisabled}/>
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="photoDisplayMode">Photo Display Mode</Label>
+                <Select value={settings.photoDisplayMode} onValueChange={(val) => handleSelectChange('photoDisplayMode', val)}>
+                    <SelectTrigger id="photoDisplayMode"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="maxWidthCrop">Max Width (Crop Vertical)</SelectItem>
+                        <SelectItem value="maxHeightCrop">Max Height (Crop Horizontal)</SelectItem>
+                        <SelectItem value="noCrop">No Cropping</SelectItem>
+                    </SelectContent>
+                </Select>
             </div>
             <div className="space-y-2">
                 <Label htmlFor="morningStartHour">Morning Starts</Label>

--- a/src/components/display-board.tsx
+++ b/src/components/display-board.tsx
@@ -1,7 +1,6 @@
 
 "use client";
 
-import Image from 'next/image';
 import { useState, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import type { Message, Photo, PhotoGroups, Settings } from '@/lib/data';
@@ -233,16 +232,31 @@ export function DisplayBoard({
 
     switch (currentItem.type) {
       case 'photo':
+        let style: React.CSSProperties = {};
+        let imgProps: Record<string, any> = {
+          src: currentItem.src!,
+          alt: currentItem.alt || '',
+          'data-ai-hint': currentItem['data-ai-hint'],
+        };
+        switch (settings.photoDisplayMode) {
+          case 'maxWidthCrop':
+            style = { width: '100%', height: 'auto', objectFit: 'cover' };
+            break;
+          case 'maxHeightCrop':
+            style = { width: 'auto', height: '100%', objectFit: 'cover' };
+            break;
+          case 'noCrop':
+          default:
+            style = { width: '100%', height: '100%', objectFit: 'contain' };
+            break;
+        }
         return (
-          <div key={key} className="relative h-full w-full animate-fade-in">
-            <Image
-              src={currentItem.src!}
-              alt={currentItem.alt || ''}
-              fill={true}
-              style={{ objectFit: 'cover' }}
-              data-ai-hint={currentItem['data-ai-hint']}
-              priority={true}
-            />
+          <div
+            key={key}
+            className="relative flex h-full w-full items-center justify-center overflow-hidden animate-fade-in"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img {...imgProps} style={style} />
           </div>
         );
       case 'message':

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -30,6 +30,7 @@ export type Settings = {
   displayMessages: boolean;
   useBlankScreens: boolean;
   monitorActivity: boolean;
+  photoDisplayMode: 'maxWidthCrop' | 'maxHeightCrop' | 'noCrop';
   morningStartHour: number;
   afternoonStartHour: number;
   eveningStartHour: number;
@@ -48,6 +49,7 @@ export const defaultSettings: Settings = {
   displayMessages: true,
   useBlankScreens: true,
   monitorActivity: false,
+  photoDisplayMode: 'maxWidthCrop',
   morningStartHour: 6,
   afternoonStartHour: 12,
   eveningStartHour: 18,


### PR DESCRIPTION
## Summary
- add `photoDisplayMode` option in settings
- implement new image rendering logic in `DisplayBoard` to support width crop, height crop, or no crop
- expose the new setting in the admin settings page

## Testing
- `npm run typecheck` *(fails: missing dependencies)*
- `npm run lint` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5e1eee14832481c0fb0492d0608c