### PR TITLE
Add dark/light mode setting

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -37,6 +37,10 @@ export default function SettingsPage() {
         try {
             const dbSettings = await getSettings();
             setSettings(dbSettings);
+            document.documentElement.classList.toggle('dark', dbSettings.theme === 'dark');
+            try {
+              localStorage.setItem('memboard-theme', dbSettings.theme);
+            } catch {}
         } catch (error) {
             console.error("Failed to load settings from database", error);
             toast({
@@ -66,13 +70,22 @@ export default function SettingsPage() {
   const handleSelectChange = (id: keyof Settings, value: string) => {
     setSettings((prev) => ({
       ...prev,
-      [id]: id === 'photoDisplayMode' ? value : Number(value),
+      [id]: id === 'photoDisplayMode' || id === 'theme' ? value : Number(value),
     }));
+    if (id === 'theme') {
+      document.documentElement.classList.toggle('dark', value === 'dark');
+      try {
+        localStorage.setItem('memboard-theme', value);
+      } catch {}
+    }
   };
 
   const handleSaveChanges = async () => {
     try {
       await saveSettings(settings);
+      try {
+        localStorage.setItem('memboard-theme', settings.theme);
+      } catch {}
       toast({
         title: 'Settings Saved',
         description: 'Your configuration has been updated successfully.',
@@ -89,6 +102,10 @@ export default function SettingsPage() {
   
   const handleResetToDefaults = () => {
     setSettings(defaultSettings);
+    document.documentElement.classList.toggle('dark', defaultSettings.theme === 'dark');
+    try {
+      localStorage.setItem('memboard-theme', defaultSettings.theme);
+    } catch {}
     toast({
         title: 'Settings Reset',
         description: 'Settings have been reset to their default values. Click "Save Changes" to apply.',
@@ -196,6 +213,16 @@ export default function SettingsPage() {
                     </span>
                 </Label>
                 <Switch id="monitorActivity" checked={settings.monitorActivity} onCheckedChange={(checked) => handleSwitchChange('monitorActivity', checked)} disabled={isDisabled}/>
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="theme">Theme Mode</Label>
+                <Select value={settings.theme} onValueChange={(val) => handleSelectChange('theme', val)}>
+                    <SelectTrigger id="theme"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="light">Light</SelectItem>
+                        <SelectItem value="dark">Dark</SelectItem>
+                    </SelectContent>
+                </Select>
             </div>
             <div className="space-y-3">
                 <Label htmlFor="scrollSpeed">Message Scroll Speed ({settings.scrollSpeed}%)</Label>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,11 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=PT+Sans:ital,wght@0,400;0,700;1,400;1,701&display=swap" rel="stylesheet" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => { try { const t = localStorage.getItem('memboard-theme') || 'light'; if (t === 'dark') document.documentElement.classList.add('dark'); } catch(e) {} })();`,
+          }}
+        />
       </head>
       <body className="font-body antialiased">
         {children}

--- a/src/components/display-board.tsx
+++ b/src/components/display-board.tsx
@@ -82,6 +82,7 @@ export function DisplayBoard({
           ]);
 
           setSettings(loadedSettings);
+          document.documentElement.classList.toggle('dark', loadedSettings.theme === 'dark');
 
           const monitor = loadedSettings.monitorActivity;
           if (monitor) {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -35,6 +35,7 @@ export type Settings = {
   afternoonStartHour: number;
   eveningStartHour: number;
   nightStartHour: number;
+  theme: 'light' | 'dark';
 };
 
 export const defaultSettings: Settings = {
@@ -54,4 +55,5 @@ export const defaultSettings: Settings = {
   afternoonStartHour: 12,
   eveningStartHour: 18,
   nightStartHour: 22,
+  theme: 'light',
 };


### PR DESCRIPTION
## Summary
- support `theme` in app settings
- persist theme to `localStorage`
- add theme selector in admin settings page
- apply theme on board load
- load theme on every page via script

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d61586ef483249c7fb24486af3137