### PR TITLE
Add configurable photo zoom effect

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -243,6 +243,15 @@ export default function SettingsPage() {
                     </SelectContent>
                 </Select>
             </div>
+            <div className="space-y-3">
+                <Label htmlFor="photoZoomPercent">Photo Zoom Amount ({settings.photoZoomPercent}%)</Label>
+                <Slider id="photoZoomPercent" value={[settings.photoZoomPercent]} onValueChange={(value) => handleSliderChange('photoZoomPercent', value)} max={50} step={1} disabled={isDisabled}/>
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="photoZoomDuration">Photo Zoom Duration (seconds)</Label>
+                <Input id="photoZoomDuration" type="number" value={settings.photoZoomDuration} onChange={handleInputChange} disabled={isDisabled}/>
+                <p className="text-sm text-muted-foreground">Use 0 to match the photo display time.</p>
+            </div>
             <div className="space-y-2">
                 <Label htmlFor="morningStartHour">Morning Starts</Label>
                 <Select value={String(settings.morningStartHour)} onValueChange={(val) => handleSelectChange('morningStartHour', val)}>

--- a/src/components/display-board.tsx
+++ b/src/components/display-board.tsx
@@ -8,6 +8,7 @@ import { defaultSettings } from '@/lib/data';
 import { getPhotoGroups } from '@/lib/photo-db';
 import { getMessages } from '@/lib/message-db';
 import { getSettings } from '@/lib/settings-db';
+import { cn } from '@/lib/utils';
 
 
 type DisplayItem = {
@@ -251,13 +252,28 @@ export function DisplayBoard({
             style = { width: '100%', height: '100%', objectFit: 'contain' };
             break;
         }
+        if (settings.photoZoomPercent > 0) {
+          style = {
+            ...style,
+            '--zoom-scale': 1 + settings.photoZoomPercent / 100,
+            '--zoom-duration': `${
+              settings.photoZoomDuration > 0
+                ? settings.photoZoomDuration
+                : currentItem.duration / 1000
+            }s`,
+          } as React.CSSProperties;
+        }
         return (
           <div
             key={key}
             className="relative flex h-full w-full items-center justify-center overflow-hidden animate-fade-in"
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img {...imgProps} style={style} />
+            <img
+              {...imgProps}
+              style={style}
+              className={cn(settings.photoZoomPercent > 0 ? 'animate-zoom-in' : '')}
+            />
           </div>
         );
       case 'message':

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -31,6 +31,8 @@ export type Settings = {
   useBlankScreens: boolean;
   monitorActivity: boolean;
   photoDisplayMode: 'maxWidthCrop' | 'maxHeightCrop' | 'noCrop';
+  photoZoomPercent: number;
+  photoZoomDuration: number;
   morningStartHour: number;
   afternoonStartHour: number;
   eveningStartHour: number;
@@ -51,6 +53,8 @@ export const defaultSettings: Settings = {
   useBlankScreens: true,
   monitorActivity: false,
   photoDisplayMode: 'maxWidthCrop',
+  photoZoomPercent: 0,
+  photoZoomDuration: 0,
   morningStartHour: 6,
   afternoonStartHour: 12,
   eveningStartHour: 18,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -86,12 +86,17 @@ export default {
           "from": { transform: "translateY(100%)" },
           "to": { transform: "translateY(-200%)" },
         },
+        "zoom-in": {
+          "from": { transform: "scale(1)" },
+          "to": { transform: "scale(var(--zoom-scale))" },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
         "fade-in": "fade-in 1s ease-in-out",
         "scroll-message": "scroll-message var(--scroll-duration, 30s) linear forwards",
+        "zoom-in": "zoom-in var(--zoom-duration, 10s) linear forwards",
       },
     },
   },


### PR DESCRIPTION
## Summary
- add `photoZoomPercent` and `photoZoomDuration` settings with defaults
- expose new controls in the admin settings page
- animate photos with new `zoom-in` keyframes when enabled

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d6369fb908324a8c2fd3a2b964e8d