### PR TITLE
Fix zoom out when cropping

### DIFF
--- a/src/components/display-board.tsx
+++ b/src/components/display-board.tsx
@@ -253,9 +253,14 @@ export function DisplayBoard({
             break;
         }
         if (settings.photoZoomPercent > 0) {
+          const zoomScale =
+            settings.photoDisplayMode === 'maxWidthCrop' ||
+            settings.photoDisplayMode === 'maxHeightCrop'
+              ? 1 - settings.photoZoomPercent / 100
+              : 1 + settings.photoZoomPercent / 100;
           style = {
             ...style,
-            '--zoom-scale': 1 + settings.photoZoomPercent / 100,
+            '--zoom-scale': zoomScale,
             '--zoom-duration': `${
               settings.photoZoomDuration > 0
                 ? settings.photoZoomDuration


### PR DESCRIPTION
## Summary
- invert zoom so that cropping modes zoom out instead of in

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d65937744832489dae3437fa1a24b