### PR TITLE
Add customizable zoom curves

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -70,7 +70,10 @@ export default function SettingsPage() {
   const handleSelectChange = (id: keyof Settings, value: string) => {
     setSettings((prev) => ({
       ...prev,
-      [id]: id === 'photoDisplayMode' || id === 'theme' ? value : Number(value),
+      [id]:
+        id === 'photoDisplayMode' || id === 'theme' || id === 'photoZoomCurve'
+          ? value
+          : Number(value),
     }));
     if (id === 'theme') {
       document.documentElement.classList.toggle('dark', value === 'dark');
@@ -251,6 +254,20 @@ export default function SettingsPage() {
                 <Label htmlFor="photoZoomDuration">Photo Zoom Duration (seconds)</Label>
                 <Input id="photoZoomDuration" type="number" value={settings.photoZoomDuration} onChange={handleInputChange} disabled={isDisabled}/>
                 <p className="text-sm text-muted-foreground">Use 0 to match the photo display time.</p>
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="photoZoomCurve">Photo Zoom Curve</Label>
+                <Select value={settings.photoZoomCurve} onValueChange={(val) => handleSelectChange('photoZoomCurve', val)}>
+                    <SelectTrigger id="photoZoomCurve"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="linear">Linear</SelectItem>
+                        <SelectItem value="cubic">Cubic</SelectItem>
+                        <SelectItem value="sigmoid">Sigmoid</SelectItem>
+                        <SelectItem value="quadratic">Quadratic</SelectItem>
+                        <SelectItem value="exponential">Exponential</SelectItem>
+                        <SelectItem value="logarithmic">Logarithmic</SelectItem>
+                    </SelectContent>
+                </Select>
             </div>
             <div className="space-y-2">
                 <Label htmlFor="morningStartHour">Morning Starts</Label>

--- a/src/components/display-board.tsx
+++ b/src/components/display-board.tsx
@@ -33,6 +33,25 @@ const shuffle = <T,>(array: T[]): T[] => {
   return newArray;
 };
 
+const getZoomEasing = (curve: Settings['photoZoomCurve']): string => {
+  switch (curve) {
+    case 'linear':
+      return 'linear';
+    case 'cubic':
+      return 'cubic-bezier(0.33, 0, 0.67, 1)';
+    case 'sigmoid':
+      return 'cubic-bezier(0.45, 0, 0.55, 1)';
+    case 'quadratic':
+      return 'cubic-bezier(0.5, 0, 1, 1)';
+    case 'exponential':
+      return 'cubic-bezier(0.7, 0, 1, 1)';
+    case 'logarithmic':
+      return 'cubic-bezier(0, 0, 0.3, 1)';
+    default:
+      return 'linear';
+  }
+};
+
 const isNowBetween = (start: number, end: number, hour: number) => {
   if (start <= end) {
     return hour >= start && hour < end;
@@ -266,6 +285,7 @@ export function DisplayBoard({
                 ? settings.photoZoomDuration
                 : currentItem.duration / 1000
             }s`,
+            '--zoom-easing': getZoomEasing(settings.photoZoomCurve),
           } as React.CSSProperties;
         }
         return (

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -33,6 +33,13 @@ export type Settings = {
   photoDisplayMode: 'maxWidthCrop' | 'maxHeightCrop' | 'noCrop';
   photoZoomPercent: number;
   photoZoomDuration: number;
+  photoZoomCurve:
+    | 'linear'
+    | 'cubic'
+    | 'sigmoid'
+    | 'quadratic'
+    | 'exponential'
+    | 'logarithmic';
   morningStartHour: number;
   afternoonStartHour: number;
   eveningStartHour: number;
@@ -55,6 +62,7 @@ export const defaultSettings: Settings = {
   photoDisplayMode: 'maxWidthCrop',
   photoZoomPercent: 0,
   photoZoomDuration: 0,
+  photoZoomCurve: 'linear',
   morningStartHour: 6,
   afternoonStartHour: 12,
   eveningStartHour: 18,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -96,7 +96,8 @@ export default {
         'accordion-up': 'accordion-up 0.2s ease-out',
         "fade-in": "fade-in 1s ease-in-out",
         "scroll-message": "scroll-message var(--scroll-duration, 30s) linear forwards",
-        "zoom-in": "zoom-in var(--zoom-duration, 10s) linear forwards",
+        "zoom-in":
+          "zoom-in var(--zoom-duration, 10s) var(--zoom-easing, linear) forwards",
       },
     },
   },


### PR DESCRIPTION
## Summary
- extend settings with `photoZoomCurve`
- allow choosing zoom curve in settings UI
- use new `photoZoomCurve` in `DisplayBoard`
- support configurable timing function for zoom animation

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686d67f1fdac832487f45767d6bf647e