### PR TITLE
Add curve multiplier slider

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -269,6 +269,18 @@ export default function SettingsPage() {
                     </SelectContent>
                 </Select>
             </div>
+            <div className="space-y-3">
+                <Label htmlFor="photoZoomCurveMultiplier">Curve Multiplier ({settings.photoZoomCurveMultiplier}x)</Label>
+                <Slider
+                    id="photoZoomCurveMultiplier"
+                    value={[settings.photoZoomCurveMultiplier]}
+                    onValueChange={(value) => handleSliderChange('photoZoomCurveMultiplier', value)}
+                    min={0.5}
+                    max={3}
+                    step={0.1}
+                    disabled={isDisabled}
+                />
+            </div>
             <div className="space-y-2">
                 <Label htmlFor="morningStartHour">Morning Starts</Label>
                 <Select value={String(settings.morningStartHour)} onValueChange={(val) => handleSelectChange('morningStartHour', val)}>

--- a/src/components/display-board.tsx
+++ b/src/components/display-board.tsx
@@ -33,20 +33,26 @@ const shuffle = <T,>(array: T[]): T[] => {
   return newArray;
 };
 
-const getZoomEasing = (curve: Settings['photoZoomCurve']): string => {
+const clamp = (n: number, min = 0, max = 1) => Math.min(Math.max(n, min), max);
+
+const getZoomEasing = (
+  curve: Settings['photoZoomCurve'],
+  multiplier: number
+): string => {
+  const m = multiplier || 1;
   switch (curve) {
     case 'linear':
       return 'linear';
     case 'cubic':
-      return 'cubic-bezier(0.33, 0, 0.67, 1)';
+      return `cubic-bezier(${clamp(0.33 * m)}, 0, ${clamp(0.67 * m)}, 1)`;
     case 'sigmoid':
-      return 'cubic-bezier(0.45, 0, 0.55, 1)';
+      return `cubic-bezier(${clamp(0.45 * m)}, 0, ${clamp(0.55 * m)}, 1)`;
     case 'quadratic':
-      return 'cubic-bezier(0.5, 0, 1, 1)';
+      return `cubic-bezier(${clamp(0.5 * m)}, 0, ${clamp(1 * m)}, 1)`;
     case 'exponential':
-      return 'cubic-bezier(0.7, 0, 1, 1)';
+      return `cubic-bezier(${clamp(0.7 * m)}, 0, 1, 1)`;
     case 'logarithmic':
-      return 'cubic-bezier(0, 0, 0.3, 1)';
+      return `cubic-bezier(0, 0, ${clamp(0.3 * m)}, 1)`;
     default:
       return 'linear';
   }
@@ -285,7 +291,10 @@ export function DisplayBoard({
                 ? settings.photoZoomDuration
                 : currentItem.duration / 1000
             }s`,
-            '--zoom-easing': getZoomEasing(settings.photoZoomCurve),
+            '--zoom-easing': getZoomEasing(
+              settings.photoZoomCurve,
+              settings.photoZoomCurveMultiplier
+            ),
           } as React.CSSProperties;
         }
         return (

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -40,6 +40,7 @@ export type Settings = {
     | 'quadratic'
     | 'exponential'
     | 'logarithmic';
+  photoZoomCurveMultiplier: number;
   morningStartHour: number;
   afternoonStartHour: number;
   eveningStartHour: number;
@@ -63,6 +64,7 @@ export const defaultSettings: Settings = {
   photoZoomPercent: 0,
   photoZoomDuration: 0,
   photoZoomCurve: 'linear',
+  photoZoomCurveMultiplier: 1,
   morningStartHour: 6,
   afternoonStartHour: 12,
   eveningStartHour: 18,


### PR DESCRIPTION
## Summary
- allow customizing zoom curve intensity with a new `photoZoomCurveMultiplier` setting
- implement multiplier slider on the admin settings page
- apply multiplier in zoom easing calculation

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d6c3c25848324bd5b620d4e2ff4d2