### PR TITLE
Fix zoom curve multiplier

### DIFF
--- a/src/components/display-board.tsx
+++ b/src/components/display-board.tsx
@@ -35,6 +35,9 @@ const shuffle = <T,>(array: T[]): T[] => {
 
 const clamp = (n: number, min = 0, max = 1) => Math.min(Math.max(n, min), max);
 
+const scalePoint = (x: number, multiplier: number) =>
+  x === 0 || x === 1 ? x : clamp(0.5 + (x - 0.5) * multiplier);
+
 const getZoomEasing = (
   curve: Settings['photoZoomCurve'],
   multiplier: number
@@ -44,15 +47,15 @@ const getZoomEasing = (
     case 'linear':
       return 'linear';
     case 'cubic':
-      return `cubic-bezier(${clamp(0.33 * m)}, 0, ${clamp(0.67 * m)}, 1)`;
+      return `cubic-bezier(${scalePoint(0.33, m)}, 0, ${scalePoint(0.67, m)}, 1)`;
     case 'sigmoid':
-      return `cubic-bezier(${clamp(0.45 * m)}, 0, ${clamp(0.55 * m)}, 1)`;
+      return `cubic-bezier(${scalePoint(0.45, m)}, 0, ${scalePoint(0.55, m)}, 1)`;
     case 'quadratic':
-      return `cubic-bezier(${clamp(0.5 * m)}, 0, ${clamp(1 * m)}, 1)`;
+      return `cubic-bezier(${scalePoint(0.5, m)}, 0, ${scalePoint(1, m)}, 1)`;
     case 'exponential':
-      return `cubic-bezier(${clamp(0.7 * m)}, 0, 1, 1)`;
+      return `cubic-bezier(${scalePoint(0.7, m)}, 0, ${scalePoint(1, m)}, 1)`;
     case 'logarithmic':
-      return `cubic-bezier(0, 0, ${clamp(0.3 * m)}, 1)`;
+      return `cubic-bezier(${scalePoint(0, m)}, 0, ${scalePoint(0.3, m)}, 1)`;
     default:
       return 'linear';
   }


### PR DESCRIPTION
## Summary
- adjust easing curve helper

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_686d6e8b0c508324a414edae121bc461