### PR TITLE
Increase curve multiplier range

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -276,7 +276,7 @@ export default function SettingsPage() {
                     value={[settings.photoZoomCurveMultiplier]}
                     onValueChange={(value) => handleSliderChange('photoZoomCurveMultiplier', value)}
                     min={0.5}
-                    max={3}
+                    max={5}
                     step={0.1}
                     disabled={isDisabled}
                 />


### PR DESCRIPTION
## Summary
- allow curve multiplier up to 5 for photo zoom easing

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d7100efc8832499aeefafebe7d6a0