### PR TITLE
Adjust zoom duration

### DIFF
--- a/src/components/display-board.tsx
+++ b/src/components/display-board.tsx
@@ -369,13 +369,14 @@ export function DisplayBoard({
             } else {
               zoomScale = 1;
             }
-            zoomDuration = Math.max(currentItem.duration / 1000 - 1, 0);
+            zoomDuration = Math.max(currentItem.duration / 1000 - 2, 0);
           } else {
             zoomScale = 1 + settings.photoZoomPercent / 100;
-            zoomDuration =
+            const baseDuration =
               settings.photoZoomDuration > 0
                 ? settings.photoZoomDuration
                 : currentItem.duration / 1000;
+            zoomDuration = Math.max(baseDuration - 2, 0);
           }
           style = {
             ...style,


### PR DESCRIPTION
## Summary
- ensure zoom animation ends two seconds before the next photo shows

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d7f0f794c8324acacead71ad061cc