### PR TITLE
Add zoom curve none and simplify photo zoom

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -246,20 +246,12 @@ export default function SettingsPage() {
                     </SelectContent>
                 </Select>
             </div>
-            <div className="space-y-3">
-                <Label htmlFor="photoZoomPercent">Photo Zoom Amount ({settings.photoZoomPercent}%)</Label>
-                <Slider id="photoZoomPercent" value={[settings.photoZoomPercent]} onValueChange={(value) => handleSliderChange('photoZoomPercent', value)} max={50} step={1} disabled={isDisabled}/>
-            </div>
-            <div className="space-y-2">
-                <Label htmlFor="photoZoomDuration">Photo Zoom Duration (seconds)</Label>
-                <Input id="photoZoomDuration" type="number" value={settings.photoZoomDuration} onChange={handleInputChange} disabled={isDisabled}/>
-                <p className="text-sm text-muted-foreground">Use 0 to match the photo display time.</p>
-            </div>
             <div className="space-y-2">
                 <Label htmlFor="photoZoomCurve">Photo Zoom Curve</Label>
                 <Select value={settings.photoZoomCurve} onValueChange={(val) => handleSelectChange('photoZoomCurve', val)}>
                     <SelectTrigger id="photoZoomCurve"><SelectValue /></SelectTrigger>
                     <SelectContent>
+                        <SelectItem value="none">None</SelectItem>
                         <SelectItem value="linear">Linear</SelectItem>
                         <SelectItem value="cubic">Cubic</SelectItem>
                         <SelectItem value="sigmoid">Sigmoid</SelectItem>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -31,9 +31,8 @@ export type Settings = {
   useBlankScreens: boolean;
   monitorActivity: boolean;
   photoDisplayMode: 'maxWidthCrop' | 'maxHeightCrop' | 'noCrop';
-  photoZoomPercent: number;
-  photoZoomDuration: number;
   photoZoomCurve:
+    | 'none'
     | 'linear'
     | 'cubic'
     | 'sigmoid'
@@ -61,9 +60,7 @@ export const defaultSettings: Settings = {
   useBlankScreens: true,
   monitorActivity: false,
   photoDisplayMode: 'maxWidthCrop',
-  photoZoomPercent: 0,
-  photoZoomDuration: 0,
-  photoZoomCurve: 'linear',
+  photoZoomCurve: 'none',
   photoZoomCurveMultiplier: 1,
   morningStartHour: 6,
   afternoonStartHour: 12,


### PR DESCRIPTION
## Summary
- remove zoom percentage and duration from settings
- add `none` option to zoom curve
- automatically compute zoom scaling

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d81d6ae5c83249d35354253a3d332