### PR TITLE
Trigger view refresh on admin settings change

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -88,6 +88,7 @@ export default function SettingsPage() {
       await saveSettings(settings);
       try {
         localStorage.setItem('memboard-theme', settings.theme);
+        localStorage.setItem('memboard-settings-updated', Date.now().toString());
       } catch {}
       toast({
         title: 'Settings Saved',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { DisplayBoard } from '@/components/display-board';
 import { ViewFooter } from '@/components/view-footer';
 import { ViewHeader } from '@/components/view-header';
@@ -9,6 +10,17 @@ import { cn } from '@/lib/utils';
 export default function Home() {
   const [statusMessage, setStatusMessage] = useState('All systems normal.');
   const [isBlankScreen, setIsBlankScreen] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === 'memboard-settings-updated') {
+        router.refresh();
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [router]);
 
   const handleStatusChange = useCallback((message: string) => {
     setStatusMessage(message);


### PR DESCRIPTION
## Summary
- update admin settings save handler to notify other tabs of changes
- listen for updates on the main view page and refresh automatically

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d86a489e08324bb3bc9959b2a80f1