### PR TITLE
Trigger view refresh for admin updates

### DIFF
--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -53,6 +53,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/hooks/use-toast';
 import type { Message } from '@/lib/data';
 import { getMessages, addMessage, updateMessage, deleteMessage } from '@/lib/message-db';
+import { triggerViewRefresh } from '@/lib/utils';
 
 const scheduleOptions = ['Always Active', 'Morning', 'Afternoon', 'Evening', 'Night'];
 
@@ -108,6 +109,7 @@ export default function MessagesPage() {
         setNewSchedule('');
         setIsAddDialogOpen(false);
         fetchMessages(); // Refresh list
+        triggerViewRefresh();
     } catch (error) {
         console.error("Failed to add message", error);
         toast({ variant: 'destructive', title: 'Error', description: 'Could not save the new message.' });
@@ -119,6 +121,7 @@ export default function MessagesPage() {
         await deleteMessage(id);
         toast({ title: "Success", description: "Message has been deleted." });
         fetchMessages();
+        triggerViewRefresh();
     } catch (error) {
         console.error("Failed to delete message", error);
         toast({ variant: 'destructive', title: 'Error', description: 'Could not delete the message.' });
@@ -140,6 +143,7 @@ export default function MessagesPage() {
         setIsEditDialogOpen(false);
         setEditingMessage(null);
         fetchMessages();
+        triggerViewRefresh();
     } catch (error) {
         console.error("Failed to update message", error);
         toast({ variant: 'destructive', title: 'Error', description: 'Could not update the message.' });

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -63,6 +63,7 @@ import {
   renamePhotoCategory,
   deletePhotoCategory,
 } from '@/lib/photo-db';
+import { triggerViewRefresh } from '@/lib/utils';
 
 export default function PhotosPage() {
   const { toast } = useToast();
@@ -169,6 +170,7 @@ export default function PhotosPage() {
       setNewCategoryName('');
       setIsUploadDialogOpen(false);
       fetchPhotos();
+      triggerViewRefresh();
       if (newPhotoCategory === '__NEW__') setActiveTab(targetCategory);
 
     } catch (error) {
@@ -182,6 +184,7 @@ export default function PhotosPage() {
         await deletePhoto(photo);
         toast({ title: "Success", description: "Photo deleted from the library." });
         fetchPhotos();
+        triggerViewRefresh();
     } catch (error) {
         console.error("Failed to delete photo", error);
         toast({ variant: 'destructive', title: 'Error', description: 'Could not delete the photo.' });
@@ -209,6 +212,7 @@ export default function PhotosPage() {
         setEditingPhoto(null);
         toast({ title: "Success", description: "Photo details have been updated." });
         fetchPhotos();
+        triggerViewRefresh();
     } catch(error) {
         console.error("Failed to update photo", error);
         toast({ variant: 'destructive', title: 'Error', description: 'Could not update photo details.' });
@@ -242,6 +246,7 @@ export default function PhotosPage() {
       await deletePhotoCategory(categoryName);
       toast({ title: "Category Deleted", description: `The "${categoryName}" category has been removed.` });
       fetchPhotos();
+      triggerViewRefresh();
     } catch (error) {
       console.error("Failed to delete category", error);
       toast({ variant: 'destructive', title: 'Error', description: 'Could not delete the category.' });
@@ -272,6 +277,7 @@ export default function PhotosPage() {
       setRenamingCategory(null);
       toast({ title: "Category Renamed", description: `"${oldName}" is now "${trimmedNewName}".` });
       fetchPhotos();
+      triggerViewRefresh();
       setActiveTab(trimmedNewName);
     } catch (error) {
       console.error("Failed to rename category", error);
@@ -286,6 +292,7 @@ export default function PhotosPage() {
       const data = await res.json();
       toast({ title: 'Duplicates Removed', description: `${data.removed} duplicate(s) deleted.` });
       fetchPhotos();
+      triggerViewRefresh();
     } catch (error) {
       console.error('Failed to remove duplicates', error);
       toast({ variant: 'destructive', title: 'Error', description: 'Could not remove duplicate photos.' });
@@ -310,6 +317,7 @@ export default function PhotosPage() {
       setSelectedIds(new Set());
       setSelectionMode(false);
       fetchPhotos();
+      triggerViewRefresh();
     } catch (error) {
       console.error('Failed to delete selected photos', error);
       toast({ variant: 'destructive', title: 'Error', description: 'Could not delete selected photos.' });

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -25,6 +25,7 @@ import { useToast } from '@/hooks/use-toast';
 import type { Settings } from '@/lib/data';
 import { defaultSettings } from '@/lib/data';
 import { getSettings, saveSettings } from '@/lib/settings-db';
+import { triggerViewRefresh } from '@/lib/utils';
 
 export default function SettingsPage() {
   const { toast } = useToast();
@@ -88,8 +89,8 @@ export default function SettingsPage() {
       await saveSettings(settings);
       try {
         localStorage.setItem('memboard-theme', settings.theme);
-        localStorage.setItem('memboard-settings-updated', Date.now().toString());
       } catch {}
+      triggerViewRefresh();
       toast({
         title: 'Settings Saved',
         description: 'Your configuration has been updated successfully.',
@@ -110,6 +111,7 @@ export default function SettingsPage() {
     try {
       localStorage.setItem('memboard-theme', defaultSettings.theme);
     } catch {}
+    triggerViewRefresh();
     toast({
         title: 'Settings Reset',
         description: 'Settings have been reset to their default values. Click "Save Changes" to apply.',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function triggerViewRefresh() {
+  try {
+    localStorage.setItem('memboard-settings-updated', Date.now().toString());
+  } catch {
+    // ignore write errors (e.g., SSR or private mode)
+  }
+}


### PR DESCRIPTION
## Summary
- add `triggerViewRefresh` helper
- call it whenever admin settings are saved or reset
- invoke refresh after message or photo changes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d88d9c394832492ec4bccec3650ec