### PR TITLE
Fix view page refresh

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,11 +10,13 @@ import { cn } from '@/lib/utils';
 export default function Home() {
   const [statusMessage, setStatusMessage] = useState('All systems normal.');
   const [isBlankScreen, setIsBlankScreen] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
   const router = useRouter();
 
   useEffect(() => {
     const handler = (e: StorageEvent) => {
       if (e.key === 'memboard-settings-updated') {
+        setRefreshKey((k) => k + 1);
         router.refresh();
       }
     };
@@ -41,6 +43,7 @@ export default function Home() {
         <ViewHeader />
         <div className="flex-1 overflow-hidden">
           <DisplayBoard
+            key={refreshKey}
             onStatusChange={handleStatusChange}
             onBlankScreenChange={handleBlankScreenChange}
           />


### PR DESCRIPTION
## Summary
- ensure DisplayBoard remounts when settings change

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d8b9fa6948324b381271361484a1e