### PR TITLE
Fix category checkbox logic

### DIFF
--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -258,12 +258,19 @@ export default function SettingsPage() {
                                       }
                                       onCheckedChange={(checked) =>
                                           setSettings((prev) => {
-                                              const selected = prev.enabledPhotoCategories || [];
+                                              const allCats = Object.keys(photoGroups).sort();
+                                              let selected =
+                                                  prev.enabledPhotoCategories && prev.enabledPhotoCategories.length > 0
+                                                      ? prev.enabledPhotoCategories
+                                                      : allCats;
                                               let newSelected = selected;
                                               if (checked) {
                                                   newSelected = Array.from(new Set([...selected, cat]));
                                               } else {
                                                   newSelected = selected.filter((c) => c !== cat);
+                                              }
+                                              if (newSelected.length === allCats.length) {
+                                                  newSelected = [];
                                               }
                                               return { ...prev, enabledPhotoCategories: newSelected };
                                           })


### PR DESCRIPTION
## Summary
- fix Visible Photo Categories checkbox logic so deselecting works

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cd9253fc8324b0ee61abbafe7b23